### PR TITLE
New membership page

### DIFF
--- a/board.html
+++ b/board.html
@@ -53,6 +53,7 @@
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-right">
             <li class="active"><a href="board.html">Board</a></li>
+            <li><a href="members.html">Members</a></li>
             <li><a href="https://docs.google.com/forms/d/1hFXHu1i4bjWWqiMGesxLn_h616ryGTgZVdteh2PlyvM/viewform">Join</a></li>
             <li><a href="http://bitcoinswitzerland.wordpress.com/">Blog</a></li>
             <li><a href="http://www.meetup.com/Bitcoin-Meetup-Switzerland/">Events</a></li>

--- a/custom.css
+++ b/custom.css
@@ -19,3 +19,16 @@ body {
 /*.members div:last-child{text-align:right}*/
 /*.members div:first-child{text-align:left}*/
 .members ul{margin:0;padding:0;clear:both;list-style-type:none}
+
+.lifetime_members{display:inline;float:left;width:100%;margin-left:0%;margin-right:0%;*zoom:1;margin-bottom:1em;text-align:center}
+.lifetime_members:before,
+.lifetime_members:after{display:table;content:"";line-height:0}
+.lifetime_members:after{clear:both}
+.lifetime_members h2,
+.lifetime_members h3,
+.lifetime_members h4{margin-bottom:0.3em}
+.lifetime_members .fa{margin-right:5px}@media only screen and (min-width: 37.5em){
+    .lifetime_members div{display:inline;float:left;width:33%}}
+/*.members div:last-child{text-align:right}*/
+/*.members div:first-child{text-align:left}*/
+.lifetime_members ul{margin:50;padding:50;clear:both;list-style-type:none}

--- a/custom.css
+++ b/custom.css
@@ -7,3 +7,15 @@ body {
   color: #D7423D;
 }
 
+.members{display:inline;float:left;width:100%;margin-left:0%;margin-right:0%;*zoom:1;margin-bottom:1em;text-align:center}
+.members:before,
+.members:after{display:table;content:"";line-height:0}
+.members:after{clear:both}
+.members h2,
+.members h3,
+.members h4{margin-bottom:0.3em}
+.members .fa{margin-right:5px}@media only screen and (min-width: 37.5em){
+    .members div{display:inline;float:left;width:25%}}
+/*.members div:last-child{text-align:right}*/
+/*.members div:first-child{text-align:left}*/
+.members ul{margin:0;padding:0;clear:both;list-style-type:none}

--- a/index.html
+++ b/index.html
@@ -125,8 +125,11 @@
         </div>
 
     </div>
-    <hr>
-</div>
+        <hr>
+        <footer>
+            <p><strong>Donate:</strong> <a href="bitcoin:1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o?label=Bitcoin+Association+Switzerland+Donation">1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o</a></p>
+        </footer>
+    </div>
 
 <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
             <h3>Telegram Group</h3>
             <img src="telegram.png" alt="Telegram Screenshot">
             <p>
-                If you would like to join our <a href="https://telegram.org/">Telegram</a> group, please get in touch with Lucas (@lclc_lucas).
+                If you would like to join our <a href="https://telegram.org/">Telegram</a> group, please get in touch with Lucas (<a href="https://web.telegram.org/#/im?p=@lclc_lucas">@lclc_lucas</a>).
             </p>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 <li><a href="board.html">Board</a></li>
+                <li><a href="members.html">Members</a></li>
                 <li>
                     <a href="https://docs.google.com/forms/d/1hFXHu1i4bjWWqiMGesxLn_h616ryGTgZVdteh2PlyvM/viewform">Join</a>
                 </li>

--- a/members.html
+++ b/members.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="Swiss Bitcoin Association" />
+    <meta property="og:url" content="http://bitcoinassociation.ch/">
+    <meta property="og:image" content="http://i.imgur.com/k5LT2RE.png" />
+    <link rel="author" href="https://plus.google.com/117619289210372570957">
+
+    <title>Members | Bitcoin Association Switzerland</title>
+
+    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="custom.css">
+
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-42598064-3', 'bitcoinassociation.ch');
+    ga('send', 'pageview');
+
+    </script>
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+   </head>
+   <body>
+    <style>
+      body {
+        padding-top: 80px;
+        padding-bottom: 20px;
+      }
+    </style>
+    <div class="navbar navbar-default navbar-fixed-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/">Home</a>
+        </div>
+        <div class="navbar-collapse collapse">
+          <ul class="nav navbar-nav navbar-right">
+            <li><a href="board.html">Board</a></li>
+            <li class="active"><a href="members.html">Members</a></li>
+            <li><a href="https://docs.google.com/forms/d/1hFXHu1i4bjWWqiMGesxLn_h616ryGTgZVdteh2PlyvM/viewform">Join</a></li>
+            <li><a href="http://bitcoinswitzerland.wordpress.com/">Blog</a></li>
+            <li><a href="http://www.meetup.com/Bitcoin-Meetup-Switzerland/">Events</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+
+<h1 style="text-align: center;">Individual Members<br /></h1>
+
+<div class="article-wrap">
+
+<div class="members">
+</br>
+<div>
+
+<ul>
+<li><a href="https://twitter.com/Luzius">Luzius Meisser</a></li>
+<li><a href="https://twitter.com/MBuffenoir">Mathieu Buffenoir</a></li>
+</ul>
+</div>
+
+<div>
+<ul>
+<li><a href="https://twitter.com/lucas_lclc">Lucas Betschart</a></li>
+<li>Bernhard Müller-Hug</li>
+</ul>
+</div>
+
+<div>
+<ul>
+<li><a href="https://twitter.com/alexis_roussel">Alexis Roussel</a></li>
+<li>Raphael Voellmy</li>
+</ul>
+</div>
+
+<div>
+<ul>
+<li><a href="https://twitter.com/RogerDarin">Roger Darin</a></li>
+<li>Jonathan Cross</li>
+</ul>
+</div>
+</div>
+</div>
+
+    </br></br></br></br>
+    <hr>
+      <footer>
+        <p><strong>Donate:</strong> <a href="bitcoin:1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o?label=Bitcoin+Association+Switzerland+Donation">1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o</a></p>
+      </footer>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/members.html
+++ b/members.html
@@ -63,44 +63,82 @@
     </div>
 
 
-<h1 style="text-align: center;">Individual Members<br /></h1>
+<h1 style="text-align: center;">Lifetime Members<br/></h1>
 
-<div class="article-wrap">
+<div class="lifetime_members">
+</br>
 
+<div>
+<ul>
+<li><a href="https://bitcoinsuisse.ch/"><img src="bitcoinsuisse.png" alt="Bitcoin Suisse AG Logo" height="100"></a></li>
+<li><a href="http://monetas.net/"><img src="monetas.jpg" alt="Monetas Logo" height="80"></a></li>
+<li><a href="http://bitc.ch/"><img src="bitc.png" alt="BITC Logo" height="100"></a></li>
+</ul>
+</div>
+
+<div>
+<ul>
+<li><a href="http://www.blockchainsource.ch/"><img src="BlockchainSource.png" alt="Blockchain Source Logo" height="100"></a></li>
+<li><a href="https://digithink.ch/"><img src="DigiThink.png" alt="DigiThink Logo"  height="100"></a></li>
+<li><a href="http://www.gutenberg.ch"><h2>Daniel Gutenberg</h2></a></li>
+</ul>
+</div>
+
+<div>
+<ul>
+<li><a href="http://bitcoinscorner.com/"><img src="bitcoincorner.png" alt="BTC Suisse Logo" height="100"></a></li>
+<li><a href="http://bity.com//"><img src="bity.png" alt="Bity" height="100"></a></li>
+</ul>
+</div>
+
+</div> <!-- End lifetime_members -->
+
+</br>&nbsp;<hr>&nbsp;
+
+<h1 style="text-align: center;">Annual Members<br/></h1>
 <div class="members">
 </br>
-<div>
 
+<div>
 <ul>
 <li><a href="https://twitter.com/Luzius">Luzius Meisser</a></li>
-<li><a href="https://twitter.com/MBuffenoir">Mathieu Buffenoir</a></li>
-</ul>
-</div>
-
-<div>
-<ul>
 <li><a href="https://twitter.com/lucas_lclc">Lucas Betschart</a></li>
-<li>Bernhard Müller-Hug</li>
+<li>Daniela Jindra</li>
+<li>Marko Bencun</li>
+<li><a href="https://twitter.com/DarioTepoTec">Dario Duran</a></li>
 </ul>
 </div>
 
 <div>
 <ul>
-<li><a href="https://twitter.com/alexis_roussel">Alexis Roussel</a></li>
-<li>Raphael Voellmy</li>
+<li><a href="https://twitter.com/MBuffenoir">Mathieu Buffenoir</a></li>
+<li><a href="https://twitter.com/jonf3n">Jonathan Cross</a></li>
+<li>Roman Brosowski</li>
+<li>Andreas Delmenico</li>
 </ul>
 </div>
 
 <div>
 <ul>
 <li><a href="https://twitter.com/RogerDarin">Roger Darin</a></li>
-<li>Jonathan Cross</li>
+<li>Raphael Voellmy</li>
+<li>Richard Ulrich</li>
+<li>Simon Gehren</li>
 </ul>
 </div>
-</div>
+
+<div>
+<ul>
+<li><a href="http://bitcoin-stuttgart.de/">fronti</a></li>
+<li>Bernhard Müller-Hug</li>
+<li>Johanns Thusbass</li>
+<li>Francisco Javier Rial Parente</li>
+</ul>
 </div>
 
-    </br></br></br></br>
+</div>
+
+    </br></br></br></br>&nbsp;
     <hr>
       <footer>
         <p><strong>Donate:</strong> <a href="bitcoin:1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o?label=Bitcoin+Association+Switzerland+Donation">1FiroDvTrXmU8P8KpPqEVTo5byaVkg9X9o</a></p>


### PR DESCRIPTION
To add a benefit of being a member of the BAS, I'd like to introduce a members page on the website. It lists all members that pay at least X amount (to be defined, I'd say 20 CHF) per year with name (or any nickname they pick) + link to their website / twitter / ..

I've just added some example members. I don't have the full memberlist yet.

The last commit moves the lifetime members to the new member website.

The idea comes from the Bitcoin Foundation: https://bitcoinfoundation.org/member/
I think people are more likely to put in some money when everyone can see publicly how generous they are ;)

ToDo (before merging this):
- Add all current members (send out an email to them and ask if they want to be listed and if they want to have a website linked)
- Update the "Join"-form with:
  - Name displayed on the website (leave empy if you don't want to be listed)
  - URL linked to
    (https://docs.google.com/forms/d/1hFXHu1i4bjWWqiMGesxLn_h616ryGTgZVdteh2PlyvM/viewform)

(I'm sure there is lots of room for improvement in the HTML / CSS.. feel free to change it :) )
